### PR TITLE
fix subproc to not print if quiet param is passed in

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name          = "smol_k8s_lab"
-version       = "0.10.2"
+version       = "0.10.3"
 description   = "bootstrap simple projects on kubernetes with kind and k3s"
 authors       = ["Jesse Hitch <jessebot@linux.com>"]
 readme        = "README.md"

--- a/smol_k8s_lab/subproc.py
+++ b/smol_k8s_lab/subproc.py
@@ -112,7 +112,10 @@ def run_subprocess(command, **kwargs):
 
     return_code = p.returncode
     res_stdout, res_stderr = res[0].decode('UTF-8'), res[1].decode('UTF-8')
-    log.info(res_stdout)
+
+    # if quiet = True, we hide this
+    if not quiet:
+        log.info(res_stdout)
 
     # check return code, raise error if failure
     if not return_code or return_code != 0:


### PR DESCRIPTION
This will fix the bcrypted password from being printed. It's still bcrypted, but still not good form to print to console without warning and consent.