### PR TITLE
update subproc to log.debug errors, and update k0s,k3s,kind to check shutil.which() before deletion

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name          = "smol_k8s_lab"
-version       = "0.10.4"
+version       = "0.10.5"
 description   = "bootstrap simple projects on kubernetes with kind and k3s"
 authors       = ["Jesse Hitch <jessebot@linux.com>"]
 readme        = "README.md"

--- a/smol_k8s_lab/__init__.py
+++ b/smol_k8s_lab/__init__.py
@@ -160,7 +160,7 @@ def main(k8s: str = "",
 
     # setup logging immediately
     log = setup_logger(log_level, log_file)
-    log.info("Logging configured")
+    log.debug("Logging configured.")
 
     # make sure we got a valid k8s distro
     if k8s not in SUPPORTED_DISTROS:

--- a/smol_k8s_lab/console_logging.py
+++ b/smol_k8s_lab/console_logging.py
@@ -20,7 +20,7 @@ soft_theme = Theme({"info": "dim cornflower_blue",
 CONSOLE = Console(theme=soft_theme)
 
 
-def header(text):
+def header(text=""):
     """
     pretty print a header with lines extending the full width of the terminal
     """
@@ -28,20 +28,30 @@ def header(text):
     title = f'[b]☁  [/]ʕ ᵔﻌᵔʔ [cyan]{text}[/cyan] ʕᵔﻌᵔ ʔ [b]☁ [/]'
     CONSOLE.rule(title, style="cornflower_blue")
     print('')
-    return
+
+    return True
 
 
-def sub_header(text, extra_starting_blank_line=True):
+def sub_header(text="",
+               extra_starting_blank_line=True,
+               ending_blank_line=True):
     """
-    pretty print a SUB header
+    pretty print a SUB header. params:
+      text                      - "", text to pretty print. REQUIRED.
+      extra_starting_blank_line - True, optionally print 2 new lines at start
+      ending_blank_line         - True, optionally print 1 new line at end
     """
     if extra_starting_blank_line:
         print('\n')
     else:
         print('')
+
     title = f'[dim]☁  {text} ☁ [/dim]'
     CONSOLE.print(title, justify="center")
-    print('')
+
+    if ending_blank_line:
+        print('')
+
     return
 
 
@@ -50,16 +60,18 @@ def print_msg(text='', alignment='center', style='dim italic'):
     prints text centered in the width of the terminal
     """
     CONSOLE.print(text, justify=alignment, style=style)
-    return
+
+    return True
 
 
 def print_panel(content='', title_txt='', title_alignment='center',
                 border_style="light_steel_blue"):
     """
-    prints text in a box with a light_steel_blue1 border and title_txt
+    prints text in a box with a light_steel_blue border and title_txt
     """
     print('')
     panel = Panel(content, title=title_txt, title_align=title_alignment,
                   border_style=border_style)
     CONSOLE.print(panel)
-    return
+
+    return True

--- a/smol_k8s_lab/k8s_distros/k0s.py
+++ b/smol_k8s_lab/k8s_distros/k0s.py
@@ -2,7 +2,7 @@
 """
        Name: k0s
 DESCRIPTION: Install k0s
-     AUTHOR: Max!
+    AUTHORS: <https://github.com/cloudymax>, <https://github.com/jessebot>
     LICENSE: GNU AFFERO GENERAL PUBLIC LICENSE Version 3
 """
 
@@ -10,6 +10,7 @@ import logging as log
 from os import path, chmod, remove
 from pathlib import Path
 from requests import get
+from shutil import which
 from socket import gethostname
 import stat
 
@@ -85,7 +86,11 @@ def uninstall_k0s():
     """
     Stop the k0s cluster, then remove all associated resources.
     """
+    if which('k0s'):
+        subproc(['sudo k0s stop'], error_ok=True)
+        subproc(['sudo k0s reset'], error_ok=True)
+    else:
+        log.debug("K0s is already uninstalled.")
+        sub_header("K0s is already uninstalled.", False, False)
 
-    subproc(['sudo k0s stop'], error_ok=True)
-    subproc(['sudo k0s reset'], error_ok=True)
     return True

--- a/smol_k8s_lab/k8s_distros/k3s.py
+++ b/smol_k8s_lab/k8s_distros/k3s.py
@@ -9,7 +9,9 @@ import logging as log
 from os import chmod, remove
 from pathlib import Path
 import requests
+from shutil import which
 import stat
+from ..console_logging import sub_header
 from ..env_config import HOME_DIR, USER
 from ..subproc import subproc
 
@@ -52,11 +54,18 @@ def install_k3s_cluster():
     # remove the script after we're done
     remove('./install.sh')
 
-    return
+    return True
 
 
 def uninstall_k3s():
     """
-    uninstall k3s
+    uninstall k3s if k3s is present
+    returns True
     """
-    subproc(['k3s-uninstall.sh'], error_ok=True, spinner=False)
+    if which('k3s-uninstall.sh'):
+        subproc(['k3s-uninstall.sh'], error_ok=True, spinner=False)
+    else:
+        log.debug("K3s is already uninstalled.")
+        sub_header("K3s is already uninstalled.", False, False)
+
+    return True

--- a/smol_k8s_lab/k8s_distros/kind.py
+++ b/smol_k8s_lab/k8s_distros/kind.py
@@ -1,8 +1,8 @@
 #!/usr/bin/env python3.11
 """
        Name: kind
-DESCRIPTION: create or delete a kind cluster
-     AUTHOR: github.com/jessebot/smol-k8s-lab
+DESCRIPTION: create or delete a kind cluster, part of smol-k8s-lab
+     AUTHOR: <https://github.com/jessebot>
     LICENSE: GNU AFFERO GENERAL PUBLIC LICENSE Version 3
 """
 import logging as log
@@ -37,8 +37,13 @@ def install_kind_cluster():
 
 def delete_kind_cluster():
     """
-    delete kind cluster
+    delete kind cluster, if kind exists
     returns True
     """
-    subproc(['kind delete cluster'])
+    if which('kind'):
+        subproc(['kind delete cluster'])
+    else:
+        log.debug("Kind is not installed.")
+        sub_header("Kind is not installed.", False, False)
+
     return True

--- a/smol_k8s_lab/subproc.py
+++ b/smol_k8s_lab/subproc.py
@@ -105,13 +105,14 @@ def run_subprocess(command, **kwargs):
     try:
         p = Popen(command.split(), stdout=PIPE, stderr=PIPE, **kwargs)
         res = p.communicate()
+        return_code = p.returncode
     except Exception as e:
         if error_ok:
-            log.error(str(e))
+            log.debug(str(e))
+            return str(e)
         else:
             raise Exception(e)
 
-    return_code = p.returncode
     res_stdout, res_stderr = res[0].decode('UTF-8'), res[1].decode('UTF-8')
 
     # if quiet = True, or res_stdout is empty, we hide this


### PR DESCRIPTION
This should fix #35 

- If you pass `error_ok=True` to `subproc`, it will now just log.debug the error and return, instead of trying to complete the function.
- On deletion functions, k0s/k3s/kind first check if their respective commands exist with `shutil.which('their respective command')` before trying to run them and exit immediately if their distro is not installed or a cluster is not running, instead of erroring and having subproc catch it. This should speed up commands that weren't going to do anything anyway.